### PR TITLE
Added state property to request and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Sample example for authenticating ServiceNow REST API through OAuth2.0
 1. Create an OAuth endpoint for you application in ServiceNow. Please take a note of ClientID and ClientSecret.
 2. Update config file with ClientID and ClientSecret.
 3. Run `npm run server` to start backend server.
+4. Go to `http://localhost:5000/auth/login`

--- a/services/passport.js
+++ b/services/passport.js
@@ -2,6 +2,11 @@ const passport = require('passport');
 const OAuthStrategy = require('passport-oauth2');
 const keys = require('../config/keys');
 
+// https://docs.servicenow.com/bundle/madrid-platform-administration/page/administer/security/reference/oauth-auth-code-flow-state-parm.html
+OAuthStrategy.prototype.authorizationParams = function(options) {
+    return { state: 123 }
+}
+
 passport.use('servicenow',new OAuthStrategy({
     authorizationURL: 'https://<INSTANCE>.service-now.com/oauth_auth.do',
     tokenURL: 'https://<INSTANCE>.service-now.com/oauth_token.do',


### PR DESCRIPTION
Beginning in the Madrid release, the system property glide.oauth.state.parameter.required adds a State parameter for an OAuth request. For zbooted instances, the property is true. For upgraded instances, the property is not present, so the State parameter is not enabled. The State parameter is a string value, and should not contain special characters. The State parameter cannot be empty or “ ”.